### PR TITLE
Fix crash

### DIFF
--- a/LFMediaEditingController/class/vendors/LFMediaDisplayView/LFMEGifView.m
+++ b/LFMediaEditingController/class/vendors/LFMediaDisplayView/LFMEGifView.m
@@ -147,7 +147,7 @@
     _timestamp += fmin(_displayLink.duration, 1);
     
     while (_timestamp >= _duration) {
-        _duration -= _duration;
+        _timestamp -= _duration;
         
         UIImage *image = nil;
         if (_gifImage) {


### PR DESCRIPTION
Whenever the while loop is entered it will remain inside infinitely.  This usually manifests in an out of memory error and crash.
The problem is that timeStamp never decreases but duration always does, so once timeStamp is greater than duration it always will be.  The intention here, I'm certain, is to decrease timestamp by duration.  This results in the correct animation behavior.